### PR TITLE
Fix data comunicator exception

### DIFF
--- a/vcf-treegrid-pro-demo/pom.xml
+++ b/vcf-treegrid-pro-demo/pom.xml
@@ -17,7 +17,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>25.0.0</vaadin.version>
+        <vaadin.version>25.0.7</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-treegrid-pro-demo/src/main/java/com/vaadin/flow/component/treegrid/demo/TreeGridProDemoView.java
+++ b/vcf-treegrid-pro-demo/src/main/java/com/vaadin/flow/component/treegrid/demo/TreeGridProDemoView.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.theme.lumo.Lumo;
 import java.util.List;
 
 /**
- * View for {@link PaperInput} demo.
+ * View for {@link TreeGridPro} demo.
  *
  * @author Vaadin Ltd
  */
@@ -33,10 +33,10 @@ import java.util.List;
 public class TreeGridProDemoView extends VerticalLayout {
     
     public TreeGridProDemoView() {
-        createBasicPaperInputDemo();
+        createBasicTreeGridProDemo();
     }
 
-    private void createBasicPaperInputDemo() {
+    private void createBasicTreeGridProDemo() {
         List<Person> managers = DataService.getManagers();
         TreeGridPro<Person> treeGridPro = new TreeGridPro<>();
         treeGridPro.setItems(managers, this::getStaff);
@@ -44,8 +44,7 @@ public class TreeGridProDemoView extends VerticalLayout {
                 .setHeader("First name");
         treeGridPro.addEditColumn(Person::getLastName).text(Person::setLastName).setHeader("Last name");
         treeGridPro.addEditColumn(Person::getEmail).text(Person::setEmail).setHeader("Email");
-        // end-source-example
-
+      
         treeGridPro.setId("tree-grid-pro");
 
         add(treeGridPro);

--- a/vcf-treegrid-pro/pom.xml
+++ b/vcf-treegrid-pro/pom.xml
@@ -18,7 +18,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>25.0.0</vaadin.version>
+        <vaadin.version>25.0.7</vaadin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
     </properties>

--- a/vcf-treegrid-pro/src/main/java/com/vaadin/flow/component/treegrid/TreeGridPro.java
+++ b/vcf-treegrid-pro/src/main/java/com/vaadin/flow/component/treegrid/TreeGridPro.java
@@ -1157,4 +1157,9 @@ public class TreeGridPro<T> extends AbstractGridPro<T>
                         "this.$connector.scrollToItem($0, ...$1)", itemKey,
                         itemIndexPath)));
     }
+    
+    @Override
+    protected void refreshViewport() {
+        ((TreeGridDataCommunicator<T>) getDataCommunicator()).refreshViewport();
+    }
 }


### PR DESCRIPTION
This PR includes the necessary updates to avoid data comunicator exception. The fix includes:

- Update Vaadin version to 25.0.7
- Add missing refreshViewport method to TreeGridPro class

This update was requested via support ticket.

Also, this PR includes some minor updates in demo view.

Tested with Vaadin 25.0.7 (customer current used version) and latest 25.1.3.