### PR TITLE
fix: initialize treeGridConnector so hierarchy indentation renders

### DIFF
--- a/vcf-treegrid-pro/src/main/java/com/vaadin/flow/component/treegrid/TreeGridPro.java
+++ b/vcf-treegrid-pro/src/main/java/com/vaadin/flow/component/treegrid/TreeGridPro.java
@@ -98,6 +98,20 @@ public class TreeGridPro<T> extends AbstractGridPro<T>
         addTreeDataGenerator();
     }
 
+    @Override
+	protected void initConnector() {
+		// Using Page.executeJs to ensure this runs before any other
+		// executeJs calls scheduled on the component that require the
+		// connector. The tree grid relies on treeGridConnector (not the base
+		// gridConnector) to translate the server-provided flat data with
+		// per-item level information into the hierarchical, indented display.
+		getUI().orElseThrow(() -> new IllegalStateException(
+				"Connector can only be initialized for an attached Grid"))
+				.getPage().executeJs(
+						"if ($0) window.Vaadin.Flow.treeGridConnector.initLazy($0)",
+						getElement());
+	}
+
     /**
      * Adds a data generator that produces a value for the <vaadin-grid>'s
      * itemHasChildrenPath property


### PR DESCRIPTION
This PR includes fix to add missing initConnector() override.  Without it, grid element wired up the base `gridConnector` instead of `treeGridConnector`, so `__getRowLevel` never read the server-provided `item.level` and every row rendered at level 0 with no indentation. 

Same fix as in https://github.com/vaadin-component-factory/enhanced-grid-flow/pull/49

Issue fix was requested through sponsored development.